### PR TITLE
Fix spelling of reservoir

### DIFF
--- a/app/views/long-term-flood-risk/map.html
+++ b/app/views/long-term-flood-risk/map.html
@@ -113,7 +113,7 @@
 						<option value="SurfaceWater_10-SWVL" title="Surface water flood risk: water velocity in a low risk scenario">Low risk: velocity</option>
 					</optgroup>
 					<optgroup label="Flood risk from reservoirs">
-						<option value="Reservoirs_3-ROFR" title="Extent of flooding from rerservoirs">Extent of flooding</option>
+						<option value="Reservoirs_3-ROFR" title="Extent of flooding from reservoirs">Extent of flooding</option>
 						<option value="Reservoirs_4-DOFR" title="Reservoir flood risk: flood water depth">Flood depth</option>
 						<option value="Reservoirs_5-SOFR" title="Reservoir flood risk: flood water speed">Flood speed</option>
 					</optgroup>
@@ -178,7 +178,7 @@
 							</h2>
 							<ul>
 								<li id="Reservoirs_3-ROFR">
-									<a href="#Reservoirs_3-ROFR" title="Extent of flooding from rerservoirs">Extent of flooding</a>
+									<a href="#Reservoirs_3-ROFR" title="Extent of flooding from reservoirs">Extent of flooding</a>
 								</li>
 								<li id="Reservoirs_4-DOFR">
 									<a href="#Reservoirs_4-DOFR" title="Reservoir flood risk: flood water depth">Flood depth</a>


### PR DESCRIPTION
I'm not sure this is the code in use or not, but the spelling mistake is present on the live site, e.g. under the map on https://flood-warning-information.service.gov.uk/long-term-flood-risk/map?easting=406000&northing=280000&map=Reservoirs